### PR TITLE
[Bugfix:Forum] Remove unnecessary white shadow in threads

### DIFF
--- a/site/public/css/forum.css
+++ b/site/public/css/forum.css
@@ -705,7 +705,7 @@
 .thread-box-full {
     padding: 10px 20px;
     margin: 5px auto;
-    box-shadow: 4px 7px 5px #cccccc;
+    border: #808080;
 }
 /* stylelint-disable-next-line selector-class-pattern */
 .thread_box .flex-row,


### PR DESCRIPTION
Updating forum.css to remove unnecessary box-shadow in wide threads and add a gray like color to the border to improve the UI for both Light and Dark color themes.

### What is the current behavior?
There is a white shadow underneath each thread and it is not looking good in dark mode.

### What is the new behavior?
When you check forum threads in wide mode, it doesn't show a white shadow in dark mode.
(Optional) 
Instead there will be a gray color border to improve the cleaner look for both Dark and Light modes.


### Other information?
Changed forum.css -> .thread-box-full
